### PR TITLE
Remove version from Laravel docs

### DIFF
--- a/docs/03-simple-hosting/02-laravel/02-migrations.md
+++ b/docs/03-simple-hosting/02-laravel/02-migrations.md
@@ -17,7 +17,7 @@ php artisan migrate
 
 ![](https://s1.chabokan.net/docs/images/console-chabokan.jpg)
 
-> [مستند رسمی **اجرای Migration** در سرویس **Laravel**](https://laravel.com/docs/10.x/artisan#introduction)
+> [مستند رسمی **اجرای Migration** در سرویس **Laravel**](https://laravel.com/docs/artisan#introduction)
 
 ---
 <a href="https://hub.chabokan.net/fa/services/create/laravel" ><img src="https://s1.chabokan.net/docs/images/laravel-banner.png" /></a>

--- a/docs/03-simple-hosting/02-laravel/03-database.md
+++ b/docs/03-simple-hosting/02-laravel/03-database.md
@@ -37,7 +37,7 @@ DB_PASSWORD : Password
 
 ![](https://s1.chabokan.net/docs/images/python-database-connect-1.jpg)
 
-> [مستند رسمی **اتصال به دیتابیس** در سرویس **Laravel**](https://laravel.com/docs/10.x/database#configuration)
+> [مستند رسمی **اتصال به دیتابیس** در سرویس **Laravel**](https://laravel.com/docs/database#configuration)
 
 ---
 <a href="https://hub.chabokan.net/fa/services/create/laravel" ><img src="https://s1.chabokan.net/docs/images/laravel-banner.png" /></a>

--- a/docs/03-simple-hosting/02-laravel/05-email.md
+++ b/docs/03-simple-hosting/02-laravel/05-email.md
@@ -137,7 +137,7 @@ Route::get('/send-email', [EmailController::class, 'sendEmail']);
 
 حالا هنگامی که https://your-url/send-email را در مرورگر فراخوانی کنید، متد `sendEmail` از کلاس `EmailController` فعال شده و ایمیل ارسال می‌گردد.
 
-> [مستند رسمی **تنظیمات ایمیل** در سرویس **Laravel**](https://laravel.com/docs/10.x/mail#generating-mailables)
+> [مستند رسمی **تنظیمات ایمیل** در سرویس **Laravel**](https://laravel.com/docs/mail#generating-mailables)
 
 ---
 <a href="https://hub.chabokan.net/fa/services/create/laravel" ><img src="https://s1.chabokan.net/docs/images/laravel-banner.png" /></a>


### PR DESCRIPTION
The Laravel Documentation website automatically redirects users to the latest version of the docs.
If we specify the version, we need to update the links each time a new version of Laravel is released.

For example:
```text

https://laravel.com/docs/database#configuration => https://laravel.com/docs/12.x/database#configuration
```